### PR TITLE
change whitespace from normal to pre-line

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -51,7 +51,7 @@
 		width: $tooltip-max-width
 		max-width: $tooltip-max-width
 		text-overflow: clip
-		white-space: normal
+		white-space: pre-line
 		word-break: keep-all
 
 [data-tooltip]


### PR DESCRIPTION
For multiline tooltips it would be nice to accept a multi line input and preserve line breaks.
pre-line will keep the source line breaks.